### PR TITLE
功能：文件名写入tags列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@
   "scraper_sleep_interval": 3,
   "scraper_http_proxy": null,
   "renamer_template": "[maker_name][rjcode] work_name cv_list_str",
-  "renamer_exclude_square_brackets_in_work_name_flag": false
+  "renamer_exclude_square_brackets_in_work_name_flag": false,
+  "renamer_illegal_character_to_full_width_flag": false,
+  "renamer_delimiter": " ",
+  "renamer_tags_max_number": 5,
+  "renamer_tags_ordered_list": [
+    "标签1",
+    ["标签2","替换2"],
+    "标签3"
+  ]
 }
 ```
 - ```scaner_max_depth``` 扫描器的扫描深度
@@ -34,14 +42,34 @@
   - ```maker_name``` 同人作品的社团名称
   - ```release_date``` 同人作品的发售日期
   - ```cv_list_str``` 同人作品的声优列表
+  - ```tags_list_str``` 同人作品的标签（分类）列表
 
-  例如：```"renamer_template": "[maker_name] work_name (rjcode)"```<br/>
-  重命名前：```RJ149268 哀しみのイき人形```<br/>
-  重命名后：```[Hypnotic_Yanh] 哀しみのイき人形《催眠音声・男女版同梱》 (RJ149268)```
+  例如：```"renamer_template": "[maker_name] work_name (rjcode)[tags_list_str]"```<br/>
+  重命名前：```RJ298293 蓄音レヱル 紅```<br/>
+  重命名后：```[RaRo] 蓄音レヱル 紅 (RJ298293)[萌 感动 治愈 环绕音]```
 - ```renamer_exclude_square_brackets_in_work_name_flag``` 命名器的 ```work_name``` 中是否排除 ```【】``` 及其间的内容。例如：
   - ```"renamer_exclude_square_brackets_in_work_name_flag": true```<br/>
     ```work_name = "道草屋 なつな2 隣の部屋のたぬきさん。"```
   - ```"renamer_exclude_square_brackets_in_work_name_flag": false```<br/>
     ```work_name = "【お隣り耳噛み】道草屋 なつな2 隣の部屋のたぬきさん。【お隣り耳かき】"```
+- ```renamer_illegal_character_to_full_width_flag``` 命名器的新文件名中的非法字符（windows保留字）如何处理。`true`为全角化，`false`为直接删除。例如：
+  - ```"renamer_illegal_character_to_full_width_flag": true```<br/>
+    `文/件*名` → `文／件＊名`
+  - ```"renamer_illegal_character_to_full_width_flag": false```<br/>
+    `文/件*名` → `文件名`
+- ```renamer_delimiter``` 命名器将列表转为字符串时的分隔符，作用于`cv_list_str`和`tags_list_str`。
+- ```renamer_tags_max_number``` 命名器向文件名中写入标签的最大个数
+- ```renamer_tags_ordered_list``` 命名器向文件名中写入标签的优先顺序和替换标签。列表。每一项若是字符串，则为匹配的标签。若是二元列表，则为`["匹配的标签","替换的标签"]`。例如：
+  - ```
+    "renamer_delimiter": ",",
+    "renamer_tags_max_number": 4,
+    "renamer_tags_ordered_list": [
+        "标签1",
+        ["标签2","替换2"],
+        "标签3"
+    ]
+    ```
+  - 作品含有的标签：`标签6` `标签5` `标签4` `标签3` `标签2` `标签1`
+  - 文件名中的标签：`标签1,替换2,标签3,标签6`
 
 【注】**请不要使用 Windows 系统自带的「记事本」编辑配置文件**，建议使用 [Notepad3](https://www.rizonesoft.com/downloads/notepad3/)、[Notepad++](https://notepad-plus-plus.org/) 或 [Visual Studio Code](https://code.visualstudio.com/) 等专业的文本编辑器。本软件的配置文件 ```config.json``` 使用不带 BOM 的标准 UTF-8 编码，但在 Windows 记事本的语境中，所谓的「UTF-8」指的是带 BOM 的 UTF-8。因此，用 Windows 系统自带的记事本编辑配置文件后，会导致本软件无法正确读取配置。

--- a/config_file.py
+++ b/config_file.py
@@ -145,7 +145,7 @@ class ConfigFile(object):
             strerror_list.append('renamer_delimiter 应是一个字符串')
         else:
             for i in renamer_delimiter:
-                if i in '[\\/*?:"<>|]':
+                if i in r'\/:*?"<>|':
                     strerror_list.append(f'renamer_delimiter 不能含有系统保留字【{i}】')
 
         return strerror_list

--- a/config_file.py
+++ b/config_file.py
@@ -27,6 +27,10 @@ class ConfigFile(object):
         'scraper_http_proxy': None,
         'renamer_template': '[maker_name][rjcode] work_name cv_list_str',
         'renamer_exclude_square_brackets_in_work_name_flag': False,
+        'renamer_illegal_character_to_full_width_flag': False,
+        'renamer_tags_max_number': 5,  # 标签个数上限
+        'renamer_tags_delimiter': ",",  # 标签分隔符
+        'renamer_tags_ordered_list': ["标签1", ["标签2", "替换2"], "标签3"],  # 标签顺序列表，每一项可为字符串或[原标签,替换名]
     }
 
     def __init__(self, file_path: str):
@@ -67,6 +71,11 @@ class ConfigFile(object):
         renamer_template = config_dict.get('renamer_template', None)
         renamer_exclude_square_brackets_in_work_name_flag = \
             config_dict.get('renamer_exclude_square_brackets_in_work_name_flag', None)
+        renamer_illegal_character_to_full_width_flag = \
+            config_dict.get('renamer_illegal_character_to_full_width_flag', None)
+        renamer_tags_ordered_list = config_dict.get('renamer_tags_ordered_list', None)
+        renamer_tags_max_number = config_dict.get('renamer_tags_max_number', None)
+        renamer_tags_delimiter = config_dict.get('renamer_tags_delimiter', None)
 
         strerror_list = []
 
@@ -111,5 +120,32 @@ class ConfigFile(object):
         # 检查 renamer_exclude_square_brackets_in_work_name_flag
         if not isinstance(renamer_exclude_square_brackets_in_work_name_flag, bool):
             strerror_list.append('renamer_exclude_square_brackets_in_work_name_flag 应是一个布尔值')
+
+        # 检查 renamer_illegal_character_to_full_width_flag
+        if not isinstance(renamer_illegal_character_to_full_width_flag, bool):
+            strerror_list.append('renamer_illegal_character_to_full_width_flag 应是一个布尔值')
+
+        # 检查 renamer_tags_ordered_list
+        if not isinstance(renamer_tags_ordered_list, list):
+            strerror_list.append('renamer_tags_ordered_list 应是一个列表，其中每个元素是"标签名"或["标签名","替换名"]')
+        else:
+            for i in renamer_tags_ordered_list:
+                if isinstance(i, list):
+                    if not len(i) == 2 or not isinstance(i[0], str) or not isinstance(i[1], str):
+                        strerror_list.append(f'renamer_tags_ordered_list 中每个元素应是"标签名"或["标签名","替换名"]，不能为【{i}】')
+                elif not isinstance(i, str):
+                    strerror_list.append(f'renamer_tags_ordered_list 中每个元素应是"标签名"或["标签名","替换名"]，不能为【{i}】')
+
+        # 检查 renamer_tags_max_number
+        if not isinstance(renamer_tags_max_number, int) or renamer_tags_max_number < 0:
+            strerror_list.append('renamer_tags_max_number 应是大于等于 0 的整数。0为无限制')
+
+        # 检查 renamer_tags_delimiter
+        if not isinstance(renamer_tags_delimiter, str):
+            strerror_list.append('renamer_tags_delimiter 应是一个字符串')
+        else:
+            for i in renamer_tags_delimiter:
+                if i in '[\\/*?:"<>|]':
+                    strerror_list.append(f'renamer_tags_delimiter 不能含有系统保留字【{i}】')
 
         return strerror_list

--- a/config_file.py
+++ b/config_file.py
@@ -28,8 +28,8 @@ class ConfigFile(object):
         'renamer_template': '[maker_name][rjcode] work_name cv_list_str',
         'renamer_exclude_square_brackets_in_work_name_flag': False,
         'renamer_illegal_character_to_full_width_flag': False,
+        'renamer_delimiter': " ",  # 分隔符
         'renamer_tags_max_number': 5,  # 标签个数上限
-        'renamer_tags_delimiter': ",",  # 标签分隔符
         'renamer_tags_ordered_list': ["标签1", ["标签2", "替换2"], "标签3"],  # 标签顺序列表，每一项可为字符串或[原标签,替换名]
     }
 
@@ -75,7 +75,7 @@ class ConfigFile(object):
             config_dict.get('renamer_illegal_character_to_full_width_flag', None)
         renamer_tags_ordered_list = config_dict.get('renamer_tags_ordered_list', None)
         renamer_tags_max_number = config_dict.get('renamer_tags_max_number', None)
-        renamer_tags_delimiter = config_dict.get('renamer_tags_delimiter', None)
+        renamer_delimiter = config_dict.get('renamer_delimiter', None)
 
         strerror_list = []
 
@@ -140,12 +140,12 @@ class ConfigFile(object):
         if not isinstance(renamer_tags_max_number, int) or renamer_tags_max_number < 0:
             strerror_list.append('renamer_tags_max_number 应是大于等于 0 的整数。0为无限制')
 
-        # 检查 renamer_tags_delimiter
-        if not isinstance(renamer_tags_delimiter, str):
-            strerror_list.append('renamer_tags_delimiter 应是一个字符串')
+        # 检查 renamer_delimiter
+        if not isinstance(renamer_delimiter, str):
+            strerror_list.append('renamer_delimiter 应是一个字符串')
         else:
-            for i in renamer_tags_delimiter:
+            for i in renamer_delimiter:
                 if i in '[\\/*?:"<>|]':
-                    strerror_list.append(f'renamer_tags_delimiter 不能含有系统保留字【{i}】')
+                    strerror_list.append(f'renamer_delimiter 不能含有系统保留字【{i}】')
 
         return strerror_list

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import os
 import sys
@@ -14,7 +15,7 @@ from scraper import Locale, CachedScraper
 from my_frame import MyFrame
 from wx_log_handler import EVT_WX_LOG_EVENT, WxLogHandler
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 
 class MyFileDropTarget(wx.FileDropTarget):
@@ -156,13 +157,20 @@ class AppFrame(MyFrame):
             read_timeout=scraper_read_timeout,
             sleep_interval=scraper_sleep_interval,
             proxies=proxies)
+        tags_option = {
+            'ordered_list': config['renamer_tags_ordered_list'],
+            'max_number': 999999 if config['renamer_tags_max_number'] == 0 else config['renamer_tags_max_number'],
+            'delimiter': config['renamer_tags_delimiter'],
+        }
 
         # 配置 renamer
         renamer = Renamer(
             scaner=scaner,
             scraper=cached_scraper,
             template=config['renamer_template'],
-            exclude_square_brackets_in_work_name_flag=config['renamer_exclude_square_brackets_in_work_name_flag'])
+            exclude_square_brackets_in_work_name_flag=config['renamer_exclude_square_brackets_in_work_name_flag'],
+            renamer_illegal_character_to_full_width_flag=config['renamer_illegal_character_to_full_width_flag'],
+            tags_option=tags_option)
 
         # 执行重命名
         for root_path in root_path_list:

--- a/main.py
+++ b/main.py
@@ -160,7 +160,6 @@ class AppFrame(MyFrame):
         tags_option = {
             'ordered_list': config['renamer_tags_ordered_list'],
             'max_number': 999999 if config['renamer_tags_max_number'] == 0 else config['renamer_tags_max_number'],
-            'delimiter': config['renamer_tags_delimiter'],
         }
 
         # 配置 renamer
@@ -168,6 +167,7 @@ class AppFrame(MyFrame):
             scaner=scaner,
             scraper=cached_scraper,
             template=config['renamer_template'],
+            delimiter=config['renamer_delimiter'],
             exclude_square_brackets_in_work_name_flag=config['renamer_exclude_square_brackets_in_work_name_flag'],
             renamer_illegal_character_to_full_width_flag=config['renamer_illegal_character_to_full_width_flag'],
             tags_option=tags_option)

--- a/renamer.py
+++ b/renamer.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-from numpy import append
 
 from requests.exceptions import RequestException, ConnectionError, HTTPError, Timeout
 


### PR DESCRIPTION
1. 添加关键字`tags_list_str`，向新文件名中写入tags标签列表。可配置标签顺序、自定义标签名称、最大个数
2. 新文件名中非法字符（win保留字）可选直接删或全角化
3. 可更改tags_list_str和cv_list_str的分隔符
4. 更新README