### PR TITLE
增强 CV 列表自定义 + 加入文件夹封面生成功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@
   "renamer_template": "[maker_name][rjcode] work_name cv_list_str",
   "renamer_exclude_square_brackets_in_work_name_flag": false,
   "renamer_illegal_character_to_full_width_flag": false,
-  'make_folder_icon': True,
-  'remove_jpg_file': True,
   "renamer_delimiter": " ",
-  'cv_list_left': "(CV ",
-  'cv_list_right': ")",
   "renamer_tags_max_number": 5,
   "renamer_tags_ordered_list": [
     "标签1",
@@ -49,14 +45,14 @@
   - ```tags_list_str``` 同人作品的标签（分类）列表
 
   例如：```"renamer_template": "[maker_name] work_name (rjcode)[tags_list_str]"```<br/>
-  重命名前：``` 蓄音 紅```<br/>
-  重命名后：```[RaRo] 蓄音 紅 ()[萌 感动 治愈 环绕音]```
+  重命名前：```RJ298293 蓄音レヱル 紅```<br/>
+  重命名后：```[RaRo] 蓄音レヱル 紅 (RJ298293)[萌 感动 治愈 环绕音]```
 - ```renamer_exclude_square_brackets_in_work_name_flag``` 命名器的 ```work_name``` 中是否排除 ```【】``` 及其间的内容。例如：
   - ```"renamer_exclude_square_brackets_in_work_name_flag": true```<br/>
     ```work_name = "道草屋 なつな2 隣の部屋のたぬきさん。"```
   - ```"renamer_exclude_square_brackets_in_work_name_flag": false```<br/>
     ```work_name = "【お隣り耳噛み】道草屋 なつな2 隣の部屋のたぬきさん。【お隣り耳かき】"```
-- ```renamer_illegal_character_to_full_width_flag``` 命名器的新文件名中的非法字符（windows保留字）如何处理。`true` 为全角化，`false` 为直接删除。例如：
+- ```renamer_illegal_character_to_full_width_flag``` 命名器的新文件名中的非法字符（windows保留字）如何处理。`true`为全角化，`false`为直接删除。例如：
   - ```"renamer_illegal_character_to_full_width_flag": true```<br/>
     `文/件*名` → `文／件＊名`
   - ```"renamer_illegal_character_to_full_width_flag": false```<br/>
@@ -68,7 +64,7 @@
 - ```renamer_tags_max_number``` 命名器向文件名中写入标签的最大个数
 - ```renamer_tags_ordered_list``` 命名器向文件名中写入标签的优先顺序和替换标签。列表。每一项若是字符串，则为匹配的标签。若是二元列表，则为`["匹配的标签","替换的标签"]`。例如：
   - ```
-    "renamer_delimiter": " ",
+    "renamer_delimiter": ",",
     "renamer_tags_max_number": 4,
     "renamer_tags_ordered_list": [
         "标签1",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@
   "renamer_template": "[maker_name][rjcode] work_name cv_list_str",
   "renamer_exclude_square_brackets_in_work_name_flag": false,
   "renamer_illegal_character_to_full_width_flag": false,
+  'make_folder_icon': True,
+  'remove_jpg_file': True,
   "renamer_delimiter": " ",
+  'cv_list_left': "(CV ",
+  'cv_list_right': ")",
   "renamer_tags_max_number": 5,
   "renamer_tags_ordered_list": [
     "标签1",
@@ -45,23 +49,26 @@
   - ```tags_list_str``` 同人作品的标签（分类）列表
 
   例如：```"renamer_template": "[maker_name] work_name (rjcode)[tags_list_str]"```<br/>
-  重命名前：```RJ298293 蓄音レヱル 紅```<br/>
-  重命名后：```[RaRo] 蓄音レヱル 紅 (RJ298293)[萌 感动 治愈 环绕音]```
+  重命名前：``` 蓄音 紅```<br/>
+  重命名后：```[RaRo] 蓄音 紅 ()[萌 感动 治愈 环绕音]```
 - ```renamer_exclude_square_brackets_in_work_name_flag``` 命名器的 ```work_name``` 中是否排除 ```【】``` 及其间的内容。例如：
   - ```"renamer_exclude_square_brackets_in_work_name_flag": true```<br/>
     ```work_name = "道草屋 なつな2 隣の部屋のたぬきさん。"```
   - ```"renamer_exclude_square_brackets_in_work_name_flag": false```<br/>
     ```work_name = "【お隣り耳噛み】道草屋 なつな2 隣の部屋のたぬきさん。【お隣り耳かき】"```
-- ```renamer_illegal_character_to_full_width_flag``` 命名器的新文件名中的非法字符（windows保留字）如何处理。`true`为全角化，`false`为直接删除。例如：
+- ```renamer_illegal_character_to_full_width_flag``` 命名器的新文件名中的非法字符（windows保留字）如何处理。`true` 为全角化，`false` 为直接删除。例如：
   - ```"renamer_illegal_character_to_full_width_flag": true```<br/>
     `文/件*名` → `文／件＊名`
   - ```"renamer_illegal_character_to_full_width_flag": false```<br/>
     `文/件*名` → `文件名`
-- ```renamer_delimiter``` 命名器将列表转为字符串时的分隔符，作用于`cv_list_str`和`tags_list_str`。
+- ```make_folder_icon``` 是否将文件夹封面改为作品封面，`true` 为修改，`false` 反之
+- ```remove_jpg_file``` 是否保留文件夹中的作品封面图，`true` 为移除，`false` 为保留（不会消除文件夹封面）
+- ```renamer_delimiter``` 命名器将列表转为字符串时的分隔符，作用于 `cv_list_str` 和 `tags_list_str`
+- ```cv_list_left``` ```cv_list_right``` 命名器在声优列表左右外括的符号，作用于 `cv_list_str`
 - ```renamer_tags_max_number``` 命名器向文件名中写入标签的最大个数
 - ```renamer_tags_ordered_list``` 命名器向文件名中写入标签的优先顺序和替换标签。列表。每一项若是字符串，则为匹配的标签。若是二元列表，则为`["匹配的标签","替换的标签"]`。例如：
   - ```
-    "renamer_delimiter": ",",
+    "renamer_delimiter": " ",
     "renamer_tags_max_number": 4,
     "renamer_tags_ordered_list": [
         "标签1",

--- a/config_file.py
+++ b/config_file.py
@@ -28,7 +28,11 @@ class ConfigFile(object):
         'renamer_template': '[maker_name][rjcode] work_name cv_list_str',
         'renamer_exclude_square_brackets_in_work_name_flag': False,
         'renamer_illegal_character_to_full_width_flag': False,
+        'make_folder_icon': True,
+        'remove_jpg_file': True,
         'renamer_delimiter': " ",  # 分隔符
+        'cv_list_left': "(CV ",
+        'cv_list_right': ")",
         'renamer_tags_max_number': 5,  # 标签个数上限
         'renamer_tags_ordered_list': ["标签1", ["标签2", "替换2"], "标签3"],  # 标签顺序列表，每一项可为字符串或[原标签,替换名]
     }
@@ -73,9 +77,15 @@ class ConfigFile(object):
             config_dict.get('renamer_exclude_square_brackets_in_work_name_flag', None)
         renamer_illegal_character_to_full_width_flag = \
             config_dict.get('renamer_illegal_character_to_full_width_flag', None)
+        make_folder_icon = \
+            config_dict.get('make_folder_icon', None)
+        remove_jpg_file = \
+            config_dict.get('remove_jpg_file', None)
         renamer_tags_ordered_list = config_dict.get('renamer_tags_ordered_list', None)
         renamer_tags_max_number = config_dict.get('renamer_tags_max_number', None)
         renamer_delimiter = config_dict.get('renamer_delimiter', None)
+        cv_list_left = config_dict.get('cv_list_left', None)
+        cv_list_right = config_dict.get('cv_list_right', None)
 
         strerror_list = []
 
@@ -125,6 +135,14 @@ class ConfigFile(object):
         if not isinstance(renamer_illegal_character_to_full_width_flag, bool):
             strerror_list.append('renamer_illegal_character_to_full_width_flag 应是一个布尔值')
 
+        # 检查 make_folder_icon
+        if not isinstance(make_folder_icon, bool):
+            strerror_list.append('make_folder_icon 应是一个布尔值')
+
+        # 检查 remove_jpg_file
+        if not isinstance(remove_jpg_file, bool):
+            strerror_list.append('remove_jpg_file 应是一个布尔值')
+
         # 检查 renamer_tags_ordered_list
         if not isinstance(renamer_tags_ordered_list, list):
             strerror_list.append('renamer_tags_ordered_list 应是一个列表，其中每个元素是"标签名"或["标签名","替换名"]')
@@ -147,5 +165,21 @@ class ConfigFile(object):
             for i in renamer_delimiter:
                 if i in r'\/:*?"<>|':
                     strerror_list.append(f'renamer_delimiter 不能含有系统保留字【{i}】')
+
+        # 检查 cv_list_left
+        if not isinstance(cv_list_left, str):
+            strerror_list.append('cv_list_left 应是一个字符串')
+        else:
+            for i in cv_list_left:
+                if i in r'\/:*?"<>|':
+                    strerror_list.append(f'cv_list_left 不能含有系统保留字【{i}】')
+
+        # 检查 cv_list_right
+        if not isinstance(cv_list_right, str):
+            strerror_list.append('cv_list_right 应是一个字符串')
+        else:
+            for i in cv_list_right:
+                if i in r'\/:*?"<>|':
+                    strerror_list.append(f'cv_list_right 不能含有系统保留字【{i}】')
 
         return strerror_list

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from scraper import Locale, CachedScraper
 from my_frame import MyFrame
 from wx_log_handler import EVT_WX_LOG_EVENT, WxLogHandler
 
-VERSION = '0.1.1'
+VERSION = '0.2.0'
 
 
 class MyFileDropTarget(wx.FileDropTarget):
@@ -168,8 +168,12 @@ class AppFrame(MyFrame):
             scraper=cached_scraper,
             template=config['renamer_template'],
             delimiter=config['renamer_delimiter'],
+            cv_list_left=config['cv_list_left'],
+            cv_list_right=config['cv_list_right'],
             exclude_square_brackets_in_work_name_flag=config['renamer_exclude_square_brackets_in_work_name_flag'],
             renamer_illegal_character_to_full_width_flag=config['renamer_illegal_character_to_full_width_flag'],
+            make_folder_icon=config['make_folder_icon'],
+            remove_jpg_file=config['remove_jpg_file'],
             tags_option=tags_option)
 
         # 执行重命名

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,6 +1,8 @@
 import re
+import os
 import time
 from urllib.request import getproxies
+import urllib.request
 
 import requests
 from pyquery import PyQuery as pq
@@ -8,6 +10,8 @@ from pyquery import PyQuery as pq
 from scraper.dlsite import Dlsite
 from scraper.locale import Locale
 from scraper.work_metadata import WorkMetadata
+
+from PIL import Image as img
 
 
 def _getproxies():
@@ -138,3 +142,29 @@ class Scraper(object):
         html = self.__request_work_page(rjcode)
         metadata = self.__parse_metadata(html, rjcode)
         return metadata
+    
+    # 获取封面图片链接
+    def __parse_icon(self, html: str):
+        d = pq(html)
+        # parse icon
+        work_icon_url_ = str(d('#work_left > div > div > div.product-slider-data > div:nth-child(1)').attr('data-src'))
+        work_icon_url = "https:" + work_icon_url_
+        return work_icon_url
+
+    # 下载图片并生成.ico文件
+    def scrape_icon(self, rjcode: str, icon_dir: str):
+        rjcode = rjcode.upper()
+        if not Dlsite.RJCODE_PATTERN.fullmatch(rjcode):
+            raise ValueError
+        html = self.__request_work_page(rjcode)
+        imgurl = self.__parse_icon(html)
+        jpg_path = os.path.join(icon_dir + "\\" + rjcode + '.jpg')
+        urllib.request.urlretrieve(imgurl, jpg_path) # 爬取作品图片
+        image = img.open(jpg_path)
+        icon_path = os.path.join(icon_dir + "\\@folder-icon-" + rjcode + '.ico')
+        x, y = image.size
+        size = max(x, y)
+        new_im = img.new('RGBA', (size, size), (255, 255, 255, 0))
+        new_im.paste(image, ((size - x) // 2, (size - y) // 2))
+        new_im.save(icon_path)
+        return jpg_path # 返回值用于后续删存操作


### PR DESCRIPTION
- 加入自动将文件夹封面修改为作品封面的功能
- 添加关键字 `cv_list_left` `cv_list_left` 用于自定义 CV 列表两侧外括符号
- 添加配置选项 `make_folder_icon` 用于自定义是否生成封面
  - 添加配置选项 `remove_jpg_file` 用于自定义是否删除文件夹中生成的作品封面图（不会影响文件夹封面）
- 更新 README